### PR TITLE
build: ditch github packages for hub.docker.com

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 env:
-  IMAGE_NAME: dir2consul
+  IMAGE_NAME: code42software/dir2consul
 
 jobs:
 
@@ -68,11 +68,10 @@ jobs:
             --build-arg VERSION=$VERSION \
             --file Dockerfile --tag image
       - name: Log into registry
-        run: echo "${{ github.token }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+        run: echo "${{ secrets.DockerHubToken }}" | docker login -u ${{ secrets.DockerHubUsername }} --password-stdin
       - name: Push Image
         run: |
-          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
-          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          IMAGE_ID=$(echo $IMAGE_NAME | tr '[A-Z]' '[a-z]')
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
           [ "$VERSION" == "master" ] && VERSION=rc
           docker tag image $IMAGE_ID:$VERSION


### PR DESCRIPTION
GitHub packages does not allow un-authenticated docker pull of images in "public" repos. The documentation is misleading. We are switching to hub.docker.com to host the public image.